### PR TITLE
Add the manage_external parameter

### DIFF
--- a/aws-standard/README.md
+++ b/aws-standard/README.md
@@ -53,6 +53,7 @@ The following variables are required inputs and must be populated prior to begin
 These variables can be populated, but they have defaults that can also be used.
 
 * `manage_bucket`: Indicate if this terraform state should create and own the bucket. Set this to false if you are reusing an existing bucket.
+* `manage_external`: Indicate if this terraform state should create external security group rules. Set this to false if you would like to write your own rules.
 * `kms_key_id`: Specify the ARN for a KMS key to use rather than having one
   created automatically.
 * `db_username` Username that will be used to access RDS. Default: `atlas`
@@ -87,4 +88,6 @@ To upgrade your instance of Terraform Enterprise, simply update the repository c
    hostname to this value.
 * `zone_id` - The Route53 Zone ID of the load balancer for TFE. If you are
    managing DNS separately but still using Route53, this value may be useful.
+* `security_groups_external` - The id of the security group that is associated
+   with the external load balancer.
 * `url` - The URL where TFE will become available when it boots.

--- a/aws-standard/main.tf
+++ b/aws-standard/main.tf
@@ -46,6 +46,11 @@ variable "manage_bucket" {
   default     = true
 }
 
+variable "manage_external" {
+  description = "Indicate if the external Security Group rules should be created/owned by this terraform state"
+  default     = true
+}
+
 variable "key_name" {
   description = "Keypair name to use when started the instances"
 }
@@ -204,6 +209,7 @@ module "instance" {
   kms_key_id           = "${coalesce(var.kms_key_id, join("", aws_kms_key.key.*.arn))}"
   bucket_force_destroy = "${var.bucket_force_destroy}"
   manage_bucket        = "${var.manage_bucket}"
+  manage_external      = "${var.manage_external}"
   arn_partition        = "${var.arn_partition}"
   internal_elb         = "${var.internal_elb}"
 }
@@ -250,4 +256,8 @@ output "dns_name" {
 
 output "zone_id" {
   value = "${module.instance.zone_id}"
+}
+
+output "security_group_external" {
+  value = "${module.instance.security_group_external}"
 }


### PR DESCRIPTION
 Add the `manage_external` parameter to determine if default security groups rules are added to the external load balancer

Add the `security_group_external` output to share the external load balancer security group id