### PR TITLE
User Provided Security Group Control

### DIFF
--- a/aws-standard/main.tf
+++ b/aws-standard/main.tf
@@ -168,6 +168,10 @@ variable "proxy_url" {
   default     = ""
 }
 
+variable "internet_access" {
+  default = false
+}
+
 # A random identifier to use as a suffix on resource names to prevent
 # collisions when multiple instances of TFE are installed in a single AWS
 # account.
@@ -241,8 +245,11 @@ module "instance" {
   vpc_id                     = "${data.aws_subnet.instance.vpc_id}"
   cert_id                    = "${var.cert_id}"
   instance_subnet_id         = "${var.instance_subnet_id}"
+  external_security_group_id = "${var.external_security_group_id}"
+  internal_security_group_id = "${var.internal_security_group_id}"
   elb_subnet_id              = "${var.elb_subnet_id}"
   key_name                   = "${var.key_name}"
+  internet_access            = "${var.internet_access}"
   db_username                = "${var.local_db ? "atlasuser" : var.db_username}"
   db_password                = "${var.local_db ? "databasepassword" : var.db_password}"
   db_endpoint                = "${var.local_db ? "127.0.0.1:5432" : module.db.endpoint}"
@@ -258,8 +265,6 @@ module "instance" {
   internal_elb               = "${var.internal_elb}"
   ebs_redundancy             = "${(var.local_redis || var.local_db) ? var.ebs_redundancy : 0}"
   startup_script             = "${var.startup_script}"
-  external_security_group_id = "${var.external_security_group_id}"
-  internal_security_group_id = "${var.internal_security_group_id}"
   proxy_url                  = "${var.proxy_url}"
   local_setup                = "${var.local_setup}"
 }
@@ -312,4 +317,12 @@ output "zone_id" {
 
 output "iam_role" {
   value = "${module.instance.iam_role}"
+}
+
+output "external_security_group_id" {
+  value = "${module.instance.external_security_group}"
+}
+
+output "instance_security_group_id" {
+  value = "${module.instance.instance_security_group}"
 }


### PR DESCRIPTION
During setup I ran into some challenges around providing security group. Some of this is user error, I did not see the count interpolation areas until after the fact and that creates the constraints associated with non-dynamic (interp) on those vars. In order to fight that back a little I made the following changes. I also did not like that by default 0.0.0.0 was open for the instance and felt users should have to enable that choice, and I added a toggle for that.

* By default the instance nor ELB is exposed outside the VPC 
* Added toggle to enable internet access 
* Moved to security group rules which allows users to extend security groups 
* Added security groups to module outputs (instance and standard) 
* Enabled support of users to bring their own security groups (created in line or a priori by removing the count dependency)

There may be other use cases that I have broken, but this was a better experience for my install. I'm understanding if this needs significant re-work or can't be merged due to other requirements