### PR TITLE
Only allow ptfe instances to RDS database

### DIFF
--- a/aws-standard/main.tf
+++ b/aws-standard/main.tf
@@ -305,6 +305,7 @@ module "db" {
   kms_key_id              = "${coalesce(var.kms_key_id, join("", aws_kms_key.key.*.arn))}"
   snapshot_identifier     = "${var.db_snapshot_identifier}"
   db_name                 = "${var.db_name}"
+  ptfe_sg                 = "${module.instance.ptfe_sg}"
 }
 
 module "redis" {

--- a/modules/rds/rds.tf
+++ b/modules/rds/rds.tf
@@ -26,6 +26,8 @@ variable "storage_type" {}
 
 variable "kms_key_id" {}
 
+variable "ptfe_sg" {}
+
 variable "snapshot_identifier" {
   default = ""
 }
@@ -55,10 +57,10 @@ resource "aws_security_group" "rds" {
   vpc_id = "${var.vpc_id}"
 
   ingress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["${var.vpc_cidr}"]
+    protocol        = "tcp"
+    from_port       = 5432
+    to_port         = 5432
+    security_groups = ["${var.ptfe_sg}"]
   }
 
   egress {

--- a/modules/tfe-instance/aws.tf
+++ b/modules/tfe-instance/aws.tf
@@ -350,3 +350,7 @@ output "zone_id" {
 output "hostname" {
   value = "${var.hostname}"
 }
+
+output "ptfe_sg" {
+  value = "${aws_security_group.ptfe.*.id[0]}"
+}


### PR DESCRIPTION
This is to secure access to RDS instance, instead of allow the entire VPC subnets, this will allow TFE EC2 instances only.